### PR TITLE
Get Linux CI working:

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,23 +17,22 @@ env:
 # https://github.com/ruby/setup-ruby
 jobs:
 
-#  linux-compat:
-#    runs-on: ubuntu-latest
-#    strategy:
-#      matrix:
-#        image:
-#          - manylinux1-x64
-#          - manylinux1-x86
-#          - manylinux2014-x64
-#          - manylinux2014-x86
-#    steps:
-#      # We can't use the `uses: docker://image` version yet, GitHub lacks authentication for actions -> packages
-#      - name: Build ${{ env.PACKAGE_NAME }}
-#        run: |
-#          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u awslabs --password-stdin
-#          export DOCKER_IMAGE=docker.pkg.github.com/awslabs/aws-crt-builder/aws-crt-${{ matrix.image }}:${{ env.BUILDER_VERSION }}
-#          docker pull $DOCKER_IMAGE
-#          docker run --env GITHUB_REF --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --env AWS_DEFAULT_REGION $DOCKER_IMAGE build -p ${{ env.PACKAGE_NAME }}
+  linux:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [2.5, 2.6, 2.7, jruby, truffleruby]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - name: Build ${{ env.PACKAGE_NAME }} + consumers
+        run: |
+          python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
+          chmod a+x builder
+          ./builder build -p ${{ env.PACKAGE_NAME }} downstream
+
 
   windows:
     strategy:

--- a/builder.json
+++ b/builder.json
@@ -6,5 +6,22 @@
         "gem install bundler",
         "bundle install",
         "bundle exec rake release"
-    ]
+    ],
+    "targets": {
+        "linux": {
+            "_comment": "On linux platforms, the CRT needs libcrypto.a",
+            "_comment": "(part of openssl) compiled in a specific way.",
+            "_comment": "builder.pyz has a special 'libcrypto import' script",
+            "_comment": "that downloads a precompiled libcrypto and sets",
+            "_comment": "the variable 'libcrypto_path'.",
+            "imports": [
+                "libcrypto"
+            ],
+            "_comment": "The aws-crt gem uses environment variable",
+            "_comment": "'LIBCRYPTO_PATH' to let users hint where to find libcrypto",
+            "build_env": {
+                "LIBCRYPTO_PATH": "{libcrypto_path}"
+            }
+        }
+    }
 }

--- a/gems/aws-crt/ext/compile.rb
+++ b/gems/aws-crt/ext/compile.rb
@@ -5,41 +5,56 @@ require 'fileutils'
 require 'shellwords'
 require_relative '../lib/aws-crt/platforms'
 
-abort 'Missing cmake' unless find_executable 'cmake'
+CMAKE = find_executable('cmake3') || find_executable('cmake')
+abort 'Missing cmake' unless CMAKE
 
 def cmake_version
-  version_str = `cmake --version`
+  version_str = `#{CMAKE} --version`
   match = /(\d+)\.(\d+)\.(\d+)/.match(version_str)
   [match[1].to_i, match[2].to_i, match[3].to_i]
 end
 
+CMAKE_VERSION = cmake_version
+
 # whether installed cmake supports --parallel build flag
 def cmake_has_parallel_flag?
-  (cmake_version <=> [3, 12]) >= 0
+  (CMAKE_VERSION <=> [3, 12]) >= 0
 end
 
 def run_cmd(args)
-  system(*args) || raise("Error running: #{Shellwords.join(args)}")
+  cmd = Shellwords.join(args)
+  puts cmd
+  system(cmd) || raise("Error running: #{cmd}")
 end
 
 # Compile bin to expected location
 def compile_bin
-  FileUtils.chdir(File.expand_path('..', File.dirname(__FILE__))) do
-    platform = local_platform
-    native_dir = File.expand_path('./native')
-    build_dir = File.expand_path('./tmp')
-    bin_dir = crt_bin_dir(platform)
-    config_cmd = ['cmake', native_dir, "-DBIN_DIR=#{bin_dir}"]
-    build_cmd = ['cmake', '--build', build_dir, '--target', 'aws-crt']
-    build_cmd.append('--parallel') if cmake_has_parallel_flag?
+  platform = local_platform
+  native_dir = File.expand_path('../native', File.dirname(__FILE__))
+  build_dir = File.expand_path('../tmp', File.dirname(__FILE__))
+  bin_dir = crt_bin_dir(platform)
 
-    # Need to run cmake from build dir.
-    # Later versions of cmake (3.13+) can pass build dir via -B,
-    # but min supported cmake (3.1) does not support this.
-    FileUtils.mkdir_p(build_dir)
-    FileUtils.chdir(build_dir) do
-      run_cmd(config_cmd)
-      run_cmd(build_cmd)
-    end
+  config_cmd = [CMAKE, native_dir, "-DBIN_DIR=#{bin_dir}"]
+
+  # if LIBCRYPTO_PATH set in ENV, pass it to cmake via CMAKE_PREFIX_PATH
+  libcrypto_path = ENV['LIBCRYPTO_PATH']
+  if libcrypto_path
+    # if libcrypto_path is relative, make it absolute, since we run
+    # cmake from a different directory
+    libcrypto_path = File.absolute_path(libcrypto_path)
+
+    config_cmd.append("-DCMAKE_PREFIX_PATH=#{libcrypto_path}")
+  end
+
+  build_cmd = [CMAKE, '--build', build_dir, '--target', 'aws-crt']
+  build_cmd.append('--parallel') if cmake_has_parallel_flag?
+
+  # Need to run cmake from build dir.
+  # Later versions of cmake (3.13+) can pass build dir via -B,
+  # but min supported cmake (3.1) does not support this.
+  FileUtils.mkdir_p(build_dir)
+  FileUtils.chdir(build_dir) do
+    run_cmd(config_cmd)
+    run_cmd(build_cmd)
   end
 end

--- a/gems/aws-crt/ext/compile.rb
+++ b/gems/aws-crt/ext/compile.rb
@@ -5,12 +5,12 @@ require 'fileutils'
 require 'shellwords'
 require_relative '../lib/aws-crt/platforms'
 
-CMAKE = find_executable('cmake3') || find_executable('cmake')
-abort 'Missing cmake' unless CMAKE
+CMAKE_PATH = find_executable('cmake3') || find_executable('cmake')
+abort 'Missing cmake' unless CMAKE_PATH
+CMAKE = File.basename(CMAKE_PATH)
 
 def cmake_version
-  version_cmd = Shellwords.join([CMAKE, '--version'])
-  version_str = `#{version_cmd}`
+  version_str = `#{CMAKE} --version`
   match = /(\d+)\.(\d+)\.(\d+)/.match(version_str)
   [match[1].to_i, match[2].to_i, match[3].to_i]
 end
@@ -23,9 +23,11 @@ def cmake_has_parallel_flag?
 end
 
 def run_cmd(args)
-  cmd = Shellwords.join(args)
-  puts cmd
-  system(cmd) || raise("Error running: #{cmd}")
+  # use shellwords.join() for printing, don't pass that string to system().
+  # system() does better cross-platform when the args array is passed in.
+  cmd_str = Shellwords.join(args)
+  puts cmd_str
+  system(*args) || raise("Error running: #{cmd_str}")
 end
 
 def libcrypto_path

--- a/gems/aws-crt/native/CMakeLists.txt
+++ b/gems/aws-crt/native/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 3.1)
 project(aws-crt C)
 message(STATUS "CMake ${CMAKE_VERSION}")
 
+if (POLICY CMP0069)
+    cmake_policy(SET CMP0069 NEW) # Enable LTO/IPO if available in the compiler
+endif()
+
 option(BIN_DIR "Location for built library" "")
 if (BIN_DIR STREQUAL "")
     message(FATAL_ERROR "BIN_DIR must be set")


### PR DESCRIPTION
- LIBCRYPTO_PATH env variable hints where to find libcrypto (this library is only needed on Linux).
- use builder's magic libcrypto import script to download precompiled libcrypto in CI.
- use `cmake3` if present. On some linux distros, `cmake` means ancient cmake.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
