### PR TITLE
Add checksums/crc32c bindings

### DIFF
--- a/gems/aws-crt/lib/aws-crt.rb
+++ b/gems/aws-crt/lib/aws-crt.rb
@@ -15,6 +15,7 @@ require_relative 'aws-crt/auth/static_credentials_provider'
 require_relative 'aws-crt/auth/signing_config'
 require_relative 'aws-crt/auth/signable'
 require_relative 'aws-crt/auth/signer'
+require_relative 'aws-crt/checksums/crc'
 
 # Top level Amazon Web Services (AWS) namespace
 module Aws

--- a/gems/aws-crt/lib/aws-crt/checksums/crc.rb
+++ b/gems/aws-crt/lib/aws-crt/checksums/crc.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Aws
+  module Crt
+    # High level Ruby abstractions for CRT Checksums functionality
+    module Checksums
+      def self.crc32(str, previous = 0)
+        Aws::Crt::Native.crc32(
+          FFI::MemoryPointer.from_string(str),
+          str.size,
+          previous
+        )
+      end
+
+      def self.crc32c(str, previous = 0)
+        Aws::Crt::Native.crc32c(
+          FFI::MemoryPointer.from_string(str),
+          str.size,
+          previous
+        )
+      end
+    end
+  end
+end

--- a/gems/aws-crt/lib/aws-crt/native.rb
+++ b/gems/aws-crt/lib/aws-crt/native.rb
@@ -211,6 +211,10 @@ module Aws
       attach_function :aws_crt_sign_request_aws, %i[signable_ptr signing_config_ptr signing_complete_fn user_data_ptr], :int
       attach_function :aws_crt_signing_result_apply_to_http_request, %i[signing_result_ptr http_message_ptr], :int
 
+      # Checksums
+      attach_function :aws_crt_crc32, %i[pointer size_t uint32], :uint32, raise: false
+      attach_function :aws_crt_crc32c, %i[pointer size_t uint32], :uint32, raise: false
+
       # Internal testing API
       attach_function :aws_crt_test_error, [:int], :int
     end

--- a/gems/aws-crt/spec/checksums/crc_spec.rb
+++ b/gems/aws-crt/spec/checksums/crc_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require_relative '../spec_helper'
+require 'base64'
+
+def int32_to_base64(num)
+  Base64.encode64([num].pack('N'))
+end
+
+describe Aws::Crt::Checksums do
+  describe 'crc32' do
+    test_cases = [
+      { str: '', expected: "AAAAAA==\n" },
+      { str: 'abc', expected: "NSRBwg==\n" },
+      { str: 'Hello world', expected: "i9aeUg==\n" }
+    ]
+    test_cases.each do |test_case|
+      it "produces the correct checksum for '#{test_case[:str]}'" do
+        checksum = int32_to_base64(Aws::Crt::Checksums.crc32(test_case[:str]))
+        expect(checksum).to eq(test_case[:expected])
+      end
+    end
+  end
+
+  describe 'crc32c' do
+    test_cases = [
+      { str: '', expected: "AAAAAA==\n" },
+      { str: 'abc', expected: "Nks/tw==\n" },
+      { str: 'Hello world', expected: "crUfeA==\n" }
+    ]
+    test_cases.each do |test_case|
+      it "produces the correct checksum for '#{test_case[:str]}'" do
+        checksum = int32_to_base64(Aws::Crt::Checksums.crc32c(test_case[:str]))
+        expect(checksum).to eq(test_case[:expected])
+      end
+    end
+  end
+end

--- a/gems/aws-crt/spec/checksums/crc_spec.rb
+++ b/gems/aws-crt/spec/checksums/crc_spec.rb
@@ -59,7 +59,7 @@ describe Aws::Crt::Checksums do
     it 'works with a huge buffer' do
       output = Aws::Crt::Checksums.crc32(ZERO_CHAR * (INT_MAX + 5))
       expect(output).to eq(0xc622f71d)
-    rescue NoMemoryError
+    rescue NoMemoryError, RangeError
       skip 'Unable to allocate memory for crc32 huge buffer test'
     end
   end
@@ -112,7 +112,7 @@ describe Aws::Crt::Checksums do
     it 'works with a huge buffer' do
       output = Aws::Crt::Checksums.crc32c(ZERO_CHAR * (INT_MAX + 5))
       expect(output).to eq(0x572a7c8a)
-    rescue NoMemoryError
+    rescue NoMemoryError, RangeError
       skip 'Unable to allocate memory for crc32c huge buffer test'
     end
   end

--- a/gems/aws-crt/spec/checksums/crc_spec.rb
+++ b/gems/aws-crt/spec/checksums/crc_spec.rb
@@ -7,6 +7,9 @@ def int32_to_base64(num)
   Base64.encode64([num].pack('N'))
 end
 
+ZERO_CHAR = [0].pack('C*')
+INT_MAX = 2**32 - 1
+
 describe Aws::Crt::Checksums do
   describe 'crc32' do
     test_cases = [
@@ -19,6 +22,45 @@ describe Aws::Crt::Checksums do
         checksum = int32_to_base64(Aws::Crt::Checksums.crc32(test_case[:str]))
         expect(checksum).to eq(test_case[:expected])
       end
+    end
+
+    it 'works with zeros in one shot' do
+      output = Aws::Crt::Checksums.crc32(ZERO_CHAR * 32)
+      expect(output).to eq(0x190A55AD)
+    end
+
+    it 'works with zeros iterated' do
+      output = 0
+      32.times do
+        output = Aws::Crt::Checksums.crc32(ZERO_CHAR, output)
+      end
+      expect(output).to eq(0x190A55AD)
+    end
+
+    it 'works with values in one shot' do
+      buf = (0...32).to_a.pack('C*')
+      output = Aws::Crt::Checksums.crc32(buf)
+      expect(output).to eq(0x91267E8A)
+    end
+
+    it 'works with values in one shot' do
+      output = 0
+      32.times do |i|
+        output = Aws::Crt::Checksums.crc32([i].pack('C*'), output)
+      end
+      expect(output).to eq(0x91267E8A)
+    end
+
+    it 'works with a large buffer' do
+      output = Aws::Crt::Checksums.crc32(ZERO_CHAR * 25 * 2**20)
+      expect(output).to eq(0x72103906)
+    end
+
+    it 'works with a huge buffer' do
+      output = Aws::Crt::Checksums.crc32(ZERO_CHAR * (INT_MAX + 5))
+      expect(output).to eq(0xc622f71d)
+    rescue NoMemoryError
+      skip 'Unable to allocate memory for crc32 huge buffer test'
     end
   end
 
@@ -33,6 +75,45 @@ describe Aws::Crt::Checksums do
         checksum = int32_to_base64(Aws::Crt::Checksums.crc32c(test_case[:str]))
         expect(checksum).to eq(test_case[:expected])
       end
+    end
+
+    it 'works with zeros in one shot' do
+      output = Aws::Crt::Checksums.crc32c(ZERO_CHAR * 32)
+      expect(output).to eq(0x8A9136AA)
+    end
+
+    it 'works with zeros iterated' do
+      output = 0
+      32.times do
+        output = Aws::Crt::Checksums.crc32c(ZERO_CHAR, output)
+      end
+      expect(output).to eq(0x8A9136AA)
+    end
+
+    it 'works with values in one shot' do
+      buf = (0...32).to_a.pack('C*')
+      output = Aws::Crt::Checksums.crc32c(buf)
+      expect(output).to eq(0x46DD794E)
+    end
+
+    it 'works with values in one shot' do
+      output = 0
+      32.times do |i|
+        output = Aws::Crt::Checksums.crc32c([i].pack('C*'), output)
+      end
+      expect(output).to eq(0x46DD794E)
+    end
+
+    it 'works with a large buffer' do
+      output = Aws::Crt::Checksums.crc32c(ZERO_CHAR * 25 * 2**20)
+      expect(output).to eq(0xfb5b991d)
+    end
+
+    it 'works with a huge buffer' do
+      output = Aws::Crt::Checksums.crc32c(ZERO_CHAR * (INT_MAX + 5))
+      expect(output).to eq(0x572a7c8a)
+    rescue NoMemoryError
+      skip 'Unable to allocate memory for crc32c huge buffer test'
     end
   end
 end


### PR DESCRIPTION
*Description of changes:*
Add bindings for checksums /crc32c (and crc32).

Note: These bindings only work for strings, and not IO objects, however this is equivilient to the functionality provided by `Zlib` for crc32.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
