### PR TITLE
Support for Apple M1.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,6 @@ jobs:
   # It would be better to run tests natively on one of these machines, but we
   # don't currently have access to one in the cloud.
   osx-arm64-cross-compile:
-    strategy:
     runs-on: macos-latest
     steps:
       - uses: ruby/setup-ruby@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,3 +88,18 @@ jobs:
           python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
           chmod a+x builder
           ./builder build -p ${{ env.PACKAGE_NAME }} downstream
+
+  # Cross-compile for Apple silicon.
+  # It would be better to run tests natively on one of these machines, but we
+  # don't currently have access to one in the cloud.
+  osx-arm64-cross-compile:
+    strategy:
+    runs-on: macos-latest
+    steps:
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+      - name: Build ${{ env.PACKAGE_NAME }} + consumers
+        run: |
+          bundle install
+          bundle exec rake "gem:aws-crt:platform[arm64]"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,9 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
       - name: Build ${{ env.PACKAGE_NAME }} + consumers
         run: |
           bundle install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,8 +101,8 @@ jobs:
         with:
           name: out_${{ matrix.os }}_${{ matrix.arch }}
           path: |
-            aws-crt-ruby/gems/aws-crt/bin/
-            aws-crt-ruby/gems/aws-crt/pkg/
+            gems/aws-crt/bin/
+            gems/aws-crt/pkg/
 
   package:
     needs: [windows, osx, linux]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,8 @@ name: Release
 on:
   push:
     branches:
-      - '*'  # TODO: Remove after testing...
-      - 'master'
+      - 'm1'  # TODO: Remove after testing...
+      - 'main'
 
 env:
   BUILDER_VERSION: v0.8.19
@@ -78,17 +78,23 @@ jobs:
       matrix:
         os: [macos]
         ruby: [2.7]
-        arch: [x64]
+        arch: [x86_64, arm64]
     runs-on: macos-latest
     steps:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
       - name: Generate Gem artifacts
         run: |
-          python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
-          chmod a+x builder
-          ./builder build -p ${{ env.PACKAGE_NAME }} downstream
+          ruby -v
+          gem install bundler
+          bundle install
+          bundle exec rake "gem:aws-crt:platform[${{ matrix.arch }}]"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
@@ -115,10 +121,15 @@ jobs:
         with:
           name: out_windows_x64
 
-      - name: Download OSX
+      - name: Download OSX x64
         uses: actions/download-artifact@v2
         with:
-          name: out_macos_x64
+          name: out_macos_x86_64
+
+      - name: Download OSX arm64
+        uses: actions/download-artifact@v2
+        with:
+          name: out_macos_arm64
 
       - name: Download Linux x64
         uses: actions/download-artifact@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,6 @@ name: Release
 on:
   push:
     branches:
-      - 'm1'  # TODO: Remove after testing...
       - 'main'
 
 env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,8 +91,6 @@ jobs:
 
       - name: Generate Gem artifacts
         run: |
-          ruby -v
-          gem install bundler
           bundle install
           bundle exec rake "gem:aws-crt:platform[${{ matrix.arch }}]"
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ reported the issue. Please try to include as much information as you can. Detail
 ## Contributing via Pull Requests
 Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:
 
-1. You are working against the latest source on the *master* branch.
+1. You are working against the latest source on the *main* branch.
 2. You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem already.
 3. You open an issue to discuss any significant work - we would hate for your time to be wasted.
 

--- a/gems/aws-crt/ext/compile.rb
+++ b/gems/aws-crt/ext/compile.rb
@@ -41,8 +41,7 @@ def find_file(name, search_dirs, base_dir)
 end
 
 # Compile bin to expected location
-def compile_bin(cpu)
-  cpu ||= host_cpu
+def compile_bin(cpu = host_cpu)
   platform = target_platform(cpu)
   native_dir = File.expand_path('../aws-crt-ffi', File.dirname(__FILE__))
   tmp_dir = File.expand_path("../tmp/#{platform.cpu}", File.dirname(__FILE__))

--- a/gems/aws-crt/ext/compile.rb
+++ b/gems/aws-crt/ext/compile.rb
@@ -10,19 +10,6 @@ CMAKE_PATH = find_executable('cmake3') || find_executable('cmake')
 abort 'Missing cmake' unless CMAKE_PATH
 CMAKE = File.basename(CMAKE_PATH)
 
-def cmake_version
-  version_str = `#{CMAKE} --version`
-  match = /(\d+)\.(\d+)\.(\d+)/.match(version_str)
-  [match[1].to_i, match[2].to_i, match[3].to_i]
-end
-
-CMAKE_VERSION = cmake_version
-
-# whether installed cmake supports --parallel build flag
-def cmake_has_parallel_flag?
-  (CMAKE_VERSION <=> [3, 12]) >= 0
-end
-
 def run_cmd(args)
   # use shellwords.join() for printing, don't pass that string to system().
   # system() does better cross-platform when the args array is passed in.
@@ -41,15 +28,16 @@ def find_file(name, search_dirs, base_dir)
 end
 
 # Compile bin to expected location
-def compile_bin
-  platform = local_platform
+def compile_bin(cpu)
+  platform = target_platform(cpu)
   native_dir = File.expand_path('../aws-crt-ffi', File.dirname(__FILE__))
-  tmp_build_dir = File.expand_path('../tmp/build', File.dirname(__FILE__))
+  tmp_dir = File.expand_path("../tmp/#{platform.cpu}", File.dirname(__FILE__))
+  tmp_build_dir = File.expand_path('build', tmp_dir)
 
   # We need cmake to "install" aws-crt-ffi so that the binaries end up in a
   # predictable location. But cmake still adds subdirectories we don't want,
   # so we'll "install" under tmp, and manually copy to bin/ after that.
-  tmp_install_dir = File.expand_path('../tmp/install', File.dirname(__FILE__))
+  tmp_install_dir = File.expand_path('install', tmp_dir)
 
   build_type = 'RelWithDebInfo'
 
@@ -59,7 +47,11 @@ def compile_bin
     "-B#{tmp_build_dir}",
     "-DCMAKE_INSTALL_PREFIX=#{tmp_install_dir}",
     "-DCMAKE_BUILD_TYPE=#{build_type}",
+    "-DBUILD_TESTING=OFF",
   ]
+
+  # macOS can cross-compile for arm64 or x86_64 regardless of host's CPU type.
+  config_cmd.append("-DCMAKE_OSX_ARCHITECTURES=#{platform.cpu}") if platform.os == 'darwin'
 
   build_cmd = [
     CMAKE,
@@ -68,11 +60,8 @@ def compile_bin
     '--config', build_type,
   ]
 
-  # Build using all processors
-  if cmake_has_parallel_flag?
-    build_cmd.append('--parallel')
-    build_cmd.append(Etc.nprocessors.to_s)
-  end
+  # Build using all processors (cmake 3.12+ checks this ENV variable)
+  ENV['CMAKE_BUILD_PARALLEL_LEVEL'] ||= Etc.nprocessors.to_s
 
   run_cmd(config_cmd)
   run_cmd(build_cmd)

--- a/gems/aws-crt/ext/compile.rb
+++ b/gems/aws-crt/ext/compile.rb
@@ -42,6 +42,7 @@ end
 
 # Compile bin to expected location
 def compile_bin(cpu)
+  cpu ||= host_cpu
   platform = target_platform(cpu)
   native_dir = File.expand_path('../aws-crt-ffi', File.dirname(__FILE__))
   tmp_dir = File.expand_path("../tmp/#{platform.cpu}", File.dirname(__FILE__))
@@ -63,7 +64,8 @@ def compile_bin(cpu)
     '-DBUILD_TESTING=OFF',
   ]
 
-  # macOS can cross-compile for arm64 or x86_64 regardless of host's CPU type.
+  # macOS can cross-compile for arm64 or x86_64.
+  # This lets us prepare both types of gems from either type of machine.
   if platform.os == 'darwin'
     config_cmd.append("-DCMAKE_OSX_ARCHITECTURES=#{platform.cpu}")
   end

--- a/gems/aws-crt/ext/compile.rb
+++ b/gems/aws-crt/ext/compile.rb
@@ -94,5 +94,5 @@ def compile_bin(cpu)
     'lib', # some unix variants
   ]
   tmp_path = find_file(bin_name, search_dirs, tmp_install_dir)
-  FileUtils.cp(tmp_path, bin_dir)
+  FileUtils.cp(tmp_path, bin_dir, verbose: true)
 end

--- a/gems/aws-crt/lib/aws-crt/platforms.rb
+++ b/gems/aws-crt/lib/aws-crt/platforms.rb
@@ -9,11 +9,15 @@ OS_BINARIES = {
 
 DEFAULT_BINARY = 'libaws-crt-ffi.so'
 
-# @return [String] returns Gem::Platform style name for the current system
-# similar to Gem::Platform.local but will return systems host os/cpu
-# for Jruby
+# @return [Gem::Platform] similar to Gem::Platform.local but will return
+# host os/cpu for Jruby
 def local_platform
   Gem::Platform.new(host_string)
+end
+
+# @return [Gem::Platform] return Gem::Platform for host os with target cpu
+def target_platform(cpu)
+  Gem::Platform.new(target_string(cpu))
 end
 
 # @return [String] return the file name for the CRT library for the platform
@@ -31,9 +35,14 @@ def crt_bin_path(platform)
   File.expand_path(crt_bin_name(platform), crt_bin_dir(platform))
 end
 
-# @return [String] generate a string that be used with Gem::Platform
+# @return [String] generate a string that can be used with Gem::Platform
 def host_string
-  "#{host_cpu}-#{host_os}"
+  target_string(host_cpu)
+end
+
+# @return [String] generate a string that can be used with Gem::Platform
+def target_string(cpu)
+  "#{cpu}-#{host_os}"
 end
 
 # @return [String] host cpu, even on jruby

--- a/gems/aws-crt/tasks/compile.rake
+++ b/gems/aws-crt/tasks/compile.rake
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-
 desc 'Compile CRT library and move to bin. Specify [cpu] to cross-compile.'
-task :bin, [:cpu] do |t, args|
+task :bin, [:cpu] do |_, args|
   require_relative '../lib/aws-crt/platforms'
   args.with_defaults(:cpu => host_cpu)
 

--- a/gems/aws-crt/tasks/compile.rake
+++ b/gems/aws-crt/tasks/compile.rake
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
-desc 'Compile CRT library and move to bin'
-task :bin do
+
+desc 'Compile CRT library and move to bin. Specify [cpu] to cross-compile.'
+task :bin, [:cpu] do |t, args|
+  require_relative '../lib/aws-crt/platforms'
+  args.with_defaults(:cpu => host_cpu)
+
   require_relative '../ext/compile'
-  compile_bin
+  compile_bin(args[:cpu])
 end
 
 desc 'Copies all binaries from the top level bin directory'

--- a/gems/aws-crt/tasks/gem.rake
+++ b/gems/aws-crt/tasks/gem.rake
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 desc 'Build aws-crt platform gem'
-task 'gem:aws-crt:platform', [:cpu] => [:bin] do |t, args|
+task 'gem:aws-crt:platform', [:cpu] => [:bin] do |_, args|
   require 'rubygems/package'
   require 'fileutils'
   require_relative '../lib/aws-crt/platforms'

--- a/gems/aws-crt/tasks/gem.rake
+++ b/gems/aws-crt/tasks/gem.rake
@@ -1,13 +1,15 @@
 # frozen_string_literal: true
 
-desc 'Build the aws-crt gem for the local platform'
-task 'gem:aws-crt:local' => [:bin] do
+desc 'Build aws-crt platform gem'
+task 'gem:aws-crt:platform', [:cpu] => [:bin] do |t, args|
   require 'rubygems/package'
   require 'fileutils'
   require_relative '../lib/aws-crt/platforms'
 
+  args.with_defaults(:cpu => host_cpu)
+
   FileUtils.chdir('gems/aws-crt') do
-    platform = local_platform
+    platform = target_platform(args[:cpu])
     binary_name = crt_bin_name(platform)
 
     FileUtils.mkdir_p('pkg/', verbose: true)
@@ -27,7 +29,7 @@ task 'gem:aws-crt:local' => [:bin] do
 end
 
 desc 'Build the aws-crt gem for the local platform'
-task 'gem:aws-crt' => 'gem:aws-crt:local'
+task 'gem:aws-crt' => 'gem:aws-crt:platform'
 
 desc 'Build the aws-crt gem for pure-ruby'
 task 'gem:aws-crt:pure-ruby' => :clean do


### PR DESCRIPTION
Release pipeline prepares `arm64-darwin` gem.

Alter rake tasks so that macOS can cross-compile arm64 or x86_64. We need to support cross-compile because we don't have access to arm64 macOS cloud machines.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
