### PR TITLE
add additional check to osx-arm64-cross-compile CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,3 +105,4 @@ jobs:
         run: |
           bundle install
           bundle exec rake "gem:aws-crt:platform[arm64]"
+          test `lipo gems/aws-crt/bin/arm64/libaws-crt-ffi.dylib -archs` = "arm64"


### PR DESCRIPTION
ensure that it ACTUALLY compiled an arm64 binary

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
