### PR TITLE
Fix bit rot in GitHub workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,6 @@ jobs:
       - name: Build ${{ env.PACKAGE_NAME }} + consumers
         run: |
           ruby -v
-          gem install bundler
           bundle install
           bundle exec rake release
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ env:
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-crt-ruby
-  LINUX_BASE_IMAGE: ubuntu-16-x64
   RUN: ${{ github.run_id }}-${{ github.run_number }}
 
 # https://github.com/ruby/setup-ruby
@@ -21,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: [2.5, 2.6, 2.7, jruby]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04 # latest
     steps:
       - uses: ruby/setup-ruby@v1
         with:
@@ -41,7 +40,7 @@ jobs:
         arch:
           - x64
           - aarch64
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04 # latest
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v1
@@ -60,7 +59,7 @@ jobs:
           docker run --env GITHUB_REF local-${{ matrix.arch }} --version=${{env.BUILDER_VERSION}} build -p ${{ env.PACKAGE_NAME }} downstream
 
   windows:
-    runs-on: windows-latest
+    runs-on: windows-2022 # latest
     steps:
       - uses: ruby/setup-ruby@v1
         with:
@@ -79,9 +78,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos]
+        arch: [x64, arm64]
         ruby: [2.5, 2.6, 2.7, jruby]
-    runs-on: macos-latest
+        exclude:
+          # ancient ruby versions not supported on arm64 macos
+          - arch: arm64
+            ruby: 2.5
+          - arch: arm64
+            ruby: 2.6
+    # Some macos runners are x64, some are arm64, see: https://github.com/actions/runner-images#available-images
+    runs-on: ${{ matrix.arch == 'x64' && 'macos-14-large' || 'macos-14' }}
     steps:
       - uses: ruby/setup-ruby@v1
         with:
@@ -91,21 +97,3 @@ jobs:
           python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
           chmod a+x builder
           ./builder build -p ${{ env.PACKAGE_NAME }} downstream
-
-  # Cross-compile for Apple silicon.
-  # It would be better to run tests natively on one of these machines, but we
-  # don't currently have access to one in the cloud.
-  osx-arm64-cross-compile:
-    runs-on: macos-latest
-    steps:
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 2.7
-      - uses: actions/checkout@v3
-        with:
-          submodules: recursive
-      - name: Build ${{ env.PACKAGE_NAME }} + consumers
-        run: |
-          bundle install
-          bundle exec rake "gem:aws-crt:platform[arm64]"
-          test `lipo gems/aws-crt/bin/arm64/libaws-crt-ffi.dylib -archs` = "arm64"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         arch:
           - x64
           - aarch64
-    runs-on: ubuntu-24.04 # latest
+    runs-on: ubuntu-22.04 # latest
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: [2.5, 2.6, 2.7, jruby]
-    runs-on: ubuntu-24.04 # latest
+    runs-on: ubuntu-22.04 # latest
     steps:
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         arch:
           - x64
           - aarch64
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04 # latest
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v1
@@ -235,7 +235,7 @@ jobs:
 
   verify-linux-native:
     needs: [package]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04 # latest
     steps:
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
       matrix:
         os: [windows]
         arch: [x64]
-    runs-on: windows-latest
+    runs-on: windows-2022 # latest
     steps:
       - uses: ruby/setup-ruby@v1
         with:
@@ -81,7 +81,7 @@ jobs:
         os: [macos]
         ruby: [2.7]
         arch: [x86_64, arm64]
-    runs-on: macos-latest
+    runs-on: macos-14 # latest
     steps:
       - uses: ruby/setup-ruby@v1
         with:
@@ -106,7 +106,7 @@ jobs:
 
   package:
     needs: [windows, osx, linux]
-    runs-on: macos-latest
+    runs-on: macos-14 # latest
     steps:
       - uses: ruby/setup-ruby@v1
         with:
@@ -154,7 +154,7 @@ jobs:
 
   verify-mac-native:
     needs: [package]
-    runs-on: macos-latest
+    runs-on: macos-14 # latest
     steps:
       - uses: ruby/setup-ruby@v1
         with:
@@ -174,7 +174,7 @@ jobs:
 
   verify-mac-jruby:
     needs: [package]
-    runs-on: macos-latest
+    runs-on: macos-14 # latest
     steps:
       - uses: ruby/setup-ruby@v1
         with:
@@ -194,7 +194,7 @@ jobs:
 
   verify-mac-pure-ruby:
     needs: [package]
-    runs-on: macos-latest
+    runs-on: macos-14 # latest
     steps:
       - uses: ruby/setup-ruby@v1
         with:
@@ -214,7 +214,7 @@ jobs:
 
   verify-windows-native:
     needs: [package]
-    runs-on: windows-latest
+    runs-on: windows-2022 # latest
     steps:
       - uses: ruby/setup-ruby@v1
         with:
@@ -229,7 +229,6 @@ jobs:
       - name: Install Gems and Require
         run: |
           ruby -v
-          gem install bundler
           bundle install
           bundle exec rake verify-release:native
 

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -3,7 +3,7 @@ on: [push]
 
 jobs:
   rubocop:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04 # latest
 
     steps:
       - name: Checkout Sources

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -16,7 +16,6 @@ jobs:
 
       - name: Bundle install
         run: |
-          gem install bundler
           bundle install
 
       - name: Rubocop


### PR DESCRIPTION
**Issue:**

1) The `osx` CI broke, because GitHub's `macos-latest` runner changed from being x64 to being arm64. macos arm64 doesn't support older Ruby versions.

2) Some CI runs broke due to installing the latest bundler, which no longer works with Ruby 2.x

**Description of changes:**

1) Always use explicit runner versions, so CI doesn't unexpectedly break on us as frequently. I.e. ~macos-latest~ -> `macos-14`
2) Now that arm64 macos runners are available, actually run tests on them (instead of just a cross-compile)
3) Don't manually install bundler. The latest version doesn't work with Ruby 2.x. The `setup-ruby` action was already handling installing a compatible version

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
