### PR TITLE
Fix windows release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    branches:
+    branches-ignore:
       - 'main'
 
 env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    branches-ignore:
+    branches:
       - 'main'
 
 env:

--- a/builder.json
+++ b/builder.json
@@ -3,7 +3,6 @@
     "packages": [],
     "build_steps": [
         "ruby -v",
-        "command -v bundler >/dev/null 2>&1 || gem install bundler",
         "bundle install",
         "bundle exec rake release"
     ]


### PR DESCRIPTION
**Issue:**
The windows release workflow breaks, due to manual install of latest bundler, which no longer works with Ruby 2.x

**Description of changes:**
Remove manual install of bundler, the `setup-ruby` action already takes care of installing a compatible version

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
