### PR TITLE
regression labeler fix

### DIFF
--- a/.github/workflows/issue-regression-labeler.yml
+++ b/.github/workflows/issue-regression-labeler.yml
@@ -12,8 +12,7 @@ jobs:
     - name: Fetch template body
       id: check_regression
       uses: actions/github-script@v7
-      env: 
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      env:
         TEMPLATE_BODY: ${{ github.event.issue.body }}
       with:
         script: |
@@ -24,9 +23,12 @@ jobs:
     - name: Manage regression label
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        IS_REGRESSION: ${{ steps.check_regression.outputs.is_regression }}
+        ISSUE_NUMBER: ${{ github.event.issue.number }}
+        REPO: ${{ github.repository }}
       run: |
-        if [ "${{ steps.check_regression.outputs.is_regression }}" == "true" ]; then
-          gh issue edit ${{ github.event.issue.number }} --add-label "potential-regression" -R ${{ github.repository }}
+        if [ "$IS_REGRESSION" == "true" ]; then
+          gh issue edit "$ISSUE_NUMBER" --add-label "potential-regression" -R "$REPO"
         else
-          gh issue edit ${{ github.event.issue.number }} --remove-label "potential-regression" -R ${{ github.repository }}
+          gh issue edit "$ISSUE_NUMBER" --remove-label "potential-regression" -R "$REPO"
         fi


### PR DESCRIPTION
*Issue #, if available:*

Fixes GitHub Actions expression injection finding in issue-regression-labeler workflow.

Description of changes:
Move ${{ }} expressions in the run: step to intermediate environment variables to prevent potential shell injection.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
